### PR TITLE
Make sure signet configs are included in repo without exposing secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,11 @@ dist/
 **/*.d.ts
 **/*.d.ts.map
 
-# Runtime config / secrets
+# Runtime config / secrets (but allow src/config source code)
 config/
 apps/*/config/
+!apps/signet/src/config/
+!apps/signet-ui/src/config/
 .env
 *.env.local
 signet.json

--- a/apps/signet/.dockerignore
+++ b/apps/signet/.dockerignore
@@ -7,7 +7,7 @@ yarn.lock
 build
 dist
 
-# Env and config
+# Env and runtime config (src/config source code is included)
 .env*
 config/
 *.log

--- a/apps/signet/src/config/config.ts
+++ b/apps/signet/src/config/config.ts
@@ -1,0 +1,45 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+import type { ConfigFile } from './types.js';
+
+export async function loadConfig(configPath: string): Promise<ConfigFile> {
+    if (!existsSync(configPath)) {
+        // Return default config if file doesn't exist
+        return {
+            nostr: {
+                relays: ['wss://relay.damus.io', 'wss://relay.primal.net', 'wss://nos.lol'],
+            },
+            admin: {
+                npubs: [],
+                adminRelays: ['wss://relay.nsec.app'],
+                key: '',
+                notifyAdminsOnBoot: false,
+            },
+            database: 'sqlite://signet.db',
+            logs: './signet.log',
+            keys: {},
+            verbose: false,
+        };
+    }
+
+    const contents = readFileSync(configPath, 'utf8');
+    const config = JSON.parse(contents) as ConfigFile;
+
+    // Ensure required fields exist with defaults
+    config.nostr ??= { relays: ['wss://relay.damus.io'] };
+    config.admin ??= { npubs: [], adminRelays: ['wss://relay.nsec.app'], key: '' };
+    config.keys ??= {};
+    config.verbose ??= false;
+
+    return config;
+}
+
+export async function saveConfig(configPath: string, config: ConfigFile): Promise<void> {
+    const dir = dirname(configPath);
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+    }
+
+    const contents = JSON.stringify(config, null, 2);
+    writeFileSync(configPath, contents + '\n', 'utf8');
+}

--- a/apps/signet/src/config/keyring.ts
+++ b/apps/signet/src/config/keyring.ts
@@ -1,0 +1,44 @@
+import crypto from 'crypto';
+
+const ALGORITHM = 'aes-256-cbc';
+const KEY_LENGTH = 32;
+const IV_LENGTH = 16;
+
+function deriveKey(passphrase: string, salt: Buffer): Buffer {
+    return crypto.pbkdf2Sync(passphrase, salt, 100000, KEY_LENGTH, 'sha256');
+}
+
+export function encryptSecret(secret: string, passphrase: string): { iv: string; data: string } {
+    const salt = crypto.randomBytes(16);
+    const key = deriveKey(passphrase, salt);
+    const iv = crypto.randomBytes(IV_LENGTH);
+
+    const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+    let encrypted = cipher.update(secret, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+
+    // Store salt + encrypted data together
+    const combined = Buffer.concat([salt, Buffer.from(encrypted, 'hex')]);
+
+    return {
+        iv: iv.toString('hex'),
+        data: combined.toString('hex'),
+    };
+}
+
+export function decryptSecret(encrypted: { iv: string; data: string }, passphrase: string): string {
+    const iv = Buffer.from(encrypted.iv, 'hex');
+    const combined = Buffer.from(encrypted.data, 'hex');
+
+    // Extract salt and encrypted data
+    const salt = combined.subarray(0, 16);
+    const encryptedData = combined.subarray(16);
+
+    const key = deriveKey(passphrase, salt);
+
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+    let decrypted = decipher.update(encryptedData.toString('hex'), 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+
+    return decrypted;
+}

--- a/apps/signet/src/config/types.ts
+++ b/apps/signet/src/config/types.ts
@@ -1,0 +1,50 @@
+export type StoredKey = {
+    iv?: string;
+    data?: string;
+    key?: string;
+};
+
+export type AdminConfig = {
+    npubs: string[];
+    adminRelays: string[];
+    key: string;
+    secret?: string;
+    notifyAdminsOnBoot?: boolean;
+};
+
+export type Nip89Config = {
+    relays: string[];
+};
+
+export type WalletConfig = {
+    type: 'lnbits';
+    config: LnBitsWalletConfig;
+};
+
+export type LnBitsWalletConfig = {
+    endpoint: string;
+    adminKey: string;
+};
+
+export type DomainConfig = {
+    nip05?: string;
+    nip89?: Nip89Config;
+    wallet?: WalletConfig;
+};
+
+export type NostrConfig = {
+    relays: string[];
+};
+
+export type ConfigFile = {
+    nostr: NostrConfig;
+    admin: AdminConfig;
+    authPort?: number;
+    authHost?: string;
+    baseUrl?: string;
+    database?: string;
+    logs?: string;
+    keys: Record<string, StoredKey>;
+    domains?: Record<string, DomainConfig>;
+    verbose: boolean;
+};


### PR DESCRIPTION
The containers failed to build and run without these files.  
The gitignore was a little too aggressive, which probably wasn't noticed until someone else (without the local files) tried to run it :)