### PR TITLE
fix: allow .env AUTH_PORT override

### DIFF
--- a/apps/signet/src/daemon/run.ts
+++ b/apps/signet/src/daemon/run.ts
@@ -360,7 +360,7 @@ class Daemon {
     private async startWebAuth(): Promise<void> {
         // Support both new (SIGNET_*) and legacy (AUTH_*) env var names
         const portEnv = process.env.SIGNET_PORT ?? process.env.AUTH_PORT;
-        const authPort = this.config.authPort ?? (portEnv ? parseInt(portEnv, 10) : undefined);
+        const authPort = (portEnv ? parseInt(portEnv, 10) : undefined) ?? this.config.authPort;
         if (!authPort) {
             console.log('No authPort configured, HTTP server disabled');
             return;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,13 +12,13 @@ services:
       - $HOME/.signet-config:/app/config
     environment:
       DATABASE_URL: ${DATABASE_URL:-file:/app/config/signet.db}
-      SIGNET_PORT: ${SIGNET_PORT:-3000}
+      SIGNET_PORT: ${SIGNET_PORT:-${AUTH_PORT:-3000}}
       SIGNET_HOST: ${SIGNET_HOST:-0.0.0.0}
       EXTERNAL_URL: ${EXTERNAL_URL:-http://localhost:4174}
     ports:
-      - "${SIGNET_PORT:-3000}:3000"
+      - "${SIGNET_PORT:-${AUTH_PORT:-3000}}:${SIGNET_PORT:-${AUTH_PORT:-3000}}"
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/health >/dev/null 2>&1 || exit 1"]
+      test: [ "CMD-SHELL", "wget -qO- http://localhost:${SIGNET_PORT:-${AUTH_PORT:-3000}}/health >/dev/null 2>&1 || exit 1" ]
       interval: 10s
       timeout: 5s
       retries: 6
@@ -35,6 +35,6 @@ services:
     environment:
       UI_PORT: ${UI_PORT:-4174}
       UI_HOST: ${UI_HOST:-0.0.0.0}
-      DAEMON_URL: ${DAEMON_URL:-http://signet:3000}
+      DAEMON_URL: ${DAEMON_URL:-http://signet:${SIGNET_PORT:-${AUTH_PORT:-3000}}}
     ports:
       - "${UI_PORT:-4174}:${UI_PORT:-4174}"


### PR DESCRIPTION
This allows the docker build to follow the .env override of the AUTH_PORT