### PR TITLE
Remove hardcoded sqlite prebuild-install step

### DIFF
--- a/apps/signet/Dockerfile
+++ b/apps/signet/Dockerfile
@@ -16,9 +16,6 @@ COPY packages/signet-types ./packages/signet-types
 ENV CI=true
 RUN pnpm install --frozen-lockfile
 
-# Ensure better-sqlite3 native bindings are installed (prebuild-install downloads prebuilt binaries)
-RUN cd /app/node_modules/.pnpm/better-sqlite3@12.5.0/node_modules/better-sqlite3 && \
-    npx --yes prebuild-install -d
 
 # Copy source files
 COPY apps/signet ./apps/signet


### PR DESCRIPTION
`pnpm install --frozen-lockfile` just above already handles this redundant line (which also happens to block the build).

Fixes #42 